### PR TITLE
Fix: stop working when page refresh

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,22 +7,17 @@ const str = [
 ];
 
 ReactDevToolsIFrameInjectPlugin.prototype.apply = function(compiler) {
-  let hasRun = false;
-
   compiler.hooks.emit.tap("ReactDevToolsIframe", function(compilation) {
-    if (hasRun) {
-      return;
-    }
     for (i = str.length - 1; i >= 0; i--) {
       Object.keys(compilation.assets).forEach(key => {
         if (!key.match(/.js$/)) {
           return;
         }
-        compilation.assets[key]._source.children.unshift(str[i]);
+        if (compilation.assets[key]._source) {
+          compilation.assets[key]._source.children.unshift(str[i]);
+        }
       });
     }
-
-    hasRun = true;
   });
 };
 


### PR DESCRIPTION
When the webpack load for the first time, everything works fine.
However, when I refresh the page manually, I can't access the iframe elements anymore and I have to restart webpack.

This PR fixes the problem.